### PR TITLE
Declaration / undefined type fix

### DIFF
--- a/src/parser/glsl-grammar.pegjs
+++ b/src/parser/glsl-grammar.pegjs
@@ -727,7 +727,7 @@ function_call
       
       const identifier = function_identifier.partial;
       const fnName = (identifier.identifier.type === 'postfix') ?
-        identifier.identifier.expression.identifier.specifier.identifier :
+        identifier.identifier.expression.specifier.identifier :
         identifier.identifier.specifier.identifier;
       
       const n = node('function_call', { ...identifier, args, rp });

--- a/src/preprocessor/preprocessor-parser.d.ts
+++ b/src/preprocessor/preprocessor-parser.d.ts
@@ -1,8 +1,8 @@
-import type { AstNode, Program } from '../ast';
+import type {PreprocessorProgram} from "./preprocessor"
 
 export type ParserOptions = {};
 
 export function parse(
-  input: string,
-  options?: ParserOptions
+    input: string,
+    options?: ParserOptions
 ): PreprocessorProgram;


### PR DESCRIPTION
Found some issues while playing with your nice parser (thank you for this).
Here is a simple glsl to produce the undfined type in function_call rule : 
```
const float[1] map = float[1] (0.0);
void test() {
    for (int i = 0; i < map.length(); i++) {
    }
}
```