### PR TITLE
Test updates and minor refactor of location information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The [Shaderfrog](https://shaderfrog.com/app) GLSL compiler is an open source
 GLSL 1.00 and 3.00 parser and preprocessor that compiles [back to
-GLSL](parser/generator.ts). Both the parser and preprocessor can preserve
+GLSL](src/parser/generator.ts). Both the parser and preprocessor can preserve
 comments and whitespace.
 
 The parser uses PEG grammar via the Peggy Javascript library. The PEG grammars
@@ -49,7 +49,7 @@ Where `options` is:
   // The origin of the GLSL, for debugging. For example, "main.js", If the
   // parser raises an error (specifically a GrammarError), and you call
   // error.format([]) on it, the error shows { source: 'main.js', ... }
-  grammarSource: string | object,
+  grammarSource: string,
   // If true, sets location information on each AST node, in the form of
   // { column: number, line: number, offset: number }
   includeLocation: boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shaderfrog/glsl-parser",
-  "version": "0.4.3",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shaderfrog/glsl-parser",
-      "version": "0.4.3",
+      "version": "1.3.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.15.5",
@@ -2496,14 +2496,24 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001261",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz",
-      "integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==",
+      "version": "1.0.30001473",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
+      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.1",
@@ -7215,9 +7225,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001261",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz",
-      "integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==",
+      "version": "1.0.30001473",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
+      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==",
       "dev": true
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A GLSL ES 1.0 and 3.0 parser and preprocessor that can preserve whitespace and comments",
   "scripts": {
     "prepare": "npm run build && ./prepublish.sh",

--- a/src/parser/parser.d.ts
+++ b/src/parser/parser.d.ts
@@ -2,7 +2,7 @@ import type { AstNode, Program } from '../ast';
 
 export type ParserOptions = Partial<{
   quiet: boolean;
-  grammarSource: string | object;
+  grammarSource: string;
   includeLocation: boolean;
 }>;
 


### PR DESCRIPTION
- Fixes a typo in the readme
- Removes the weird object type from grammarSource
- Refactors scope location information into some functions
- Minor cleanup in parser file (use node() for entrypoint)
- Adds tests for scoping
- Updates tests to print peggy formatted errors, including for parser generation
- Bumps library version