### PR TITLE
Fixing preprocessor generate bug in ifdef & ifndef & else

### DIFF
--- a/src/preprocessor/generator.ts
+++ b/src/preprocessor/generator.ts
@@ -60,11 +60,11 @@ const generators: NodePreprocessorGenerators = {
     generate(node.wsEnd) +
     generate(node.body),
   ifdef: (node) =>
-    generate(node.token) + generate(node.identifier) + generate(node.wsEnd),
+    generate(node.token) + generate(node.identifier) + generate(node.wsEnd) + generate(node.body),
   ifndef: (node) =>
-    generate(node.token) + generate(node.identifier) + generate(node.wsEnd),
+    generate(node.token) + generate(node.identifier) + generate(node.wsEnd) + generate(node.body),
   else: (node) =>
-    generate(node.token) + generate(node.body) + generate(node.wsEnd),
+    generate(node.token) + generate(node.wsEnd) + generate(node.body),
   error: (node) =>
     generate(node.error) + generate(node.message) + generate(node.wsEnd),
 

--- a/src/preprocessor/preprocessor.test.ts
+++ b/src/preprocessor/preprocessor.test.ts
@@ -455,8 +455,29 @@ test('different line breaks character', () => {
   const program = '#ifndef x\rfloat a = 1.0;\r\n#endif';
 
   const ast = parse(program);
-  const c = preprocessAst(ast);
+  preprocessAst(ast);
   expect(generate(ast)).toBe('float a = 1.0;\r\n');
+});
+
+test('generate #ifdef & #ifndef & #else', () => {
+  const program = `
+  #ifdef AA
+    float a;
+  #else
+    float b;
+  #endif
+
+  #ifndef CC
+    float c;
+  #endif
+
+  #if AA == 2
+    float d;
+  #endif
+  `;
+
+  const ast = parse(program);
+  expect(generate(ast)).toBe(program);
 });
 
 /*


### PR DESCRIPTION
```#ifdef``` and ```#ifndef``` is missing ```body``` and ```#else``` is missing ```wsEnd``` in the generate, 

Test case:
<img width="300" alt="image" src="https://github.com/ShaderFrog/glsl-parser/assets/800043/67587bb8-14d5-411d-a3b6-580550e17033">

The result

  <img width="363" alt="image" src="https://github.com/ShaderFrog/glsl-parser/assets/800043/a1063ea9-8428-4801-b301-f7199a090510">

