### PR TITLE
Only traverse replaced node after calling .replace()

### DIFF
--- a/src/ast/visit.ts
+++ b/src/ast/visit.ts
@@ -115,19 +115,23 @@ export const visit = (ast: Program | AstNode, visitors: NodeVisitors) => {
       }
     }
 
-    Object.entries(node)
+    const toTraverse = path.replaced ?? node;
+    const newPath = path.replaced
+      ? makePath(toTraverse, parent, parentPath, key, index)
+      : path;
+    Object.entries(toTraverse)
       .filter(([_, nodeValue]) => isTraversable(nodeValue))
       .forEach(([nodeKey, nodeValue]) => {
         if (Array.isArray(nodeValue)) {
           for (let i = 0, offset = 0; i - offset < nodeValue.length; i++) {
             const child = nodeValue[i - offset];
-            const res = visitNode(child, node, path, nodeKey, i - offset);
+            const res = visitNode(child, toTraverse, newPath, nodeKey, i - offset);
             if (res?.removed) {
               offset += 1;
             }
           }
         } else {
-          visitNode(nodeValue, node, path, nodeKey);
+          visitNode(nodeValue, toTraverse, newPath, nodeKey);
         }
       });
 

--- a/src/ast/visit.ts
+++ b/src/ast/visit.ts
@@ -115,7 +115,7 @@ export const visit = (ast: Program | AstNode, visitors: NodeVisitors) => {
       }
     }
 
-    const toTraverse = path.replaced ?? node;
+    const toTraverse = (path.replaced as AstNode | undefined) ?? node;
     const newPath = path.replaced
       ? makePath(toTraverse, parent, parentPath, key, index)
       : path;

--- a/src/preprocessor/preprocessor.test.ts
+++ b/src/preprocessor/preprocessor.test.ts
@@ -117,6 +117,39 @@ true
 `);
 });
 
+test('define inside if/else is properly expanded when the if branch is chosen', () => {
+  const program = `
+#define MACRO
+#ifdef MACRO
+#define BRANCH a
+#else
+#define BRANCH b
+#endif
+BRANCH
+`;
+  const ast = parse(program);
+  preprocessAst(ast);
+  expect(generate(ast)).toBe(`
+a
+`);
+});
+
+test('define inside if/else is properly expanded when the else branch is chosen', () => {
+  const program = `
+#ifdef MACRO
+#define BRANCH a
+#else
+#define BRANCH b
+#endif
+BRANCH
+`;
+  const ast = parse(program);
+  preprocessAst(ast);
+  expect(generate(ast)).toBe(`
+b
+`);
+});
+
 test('ifdef inside else is properly expanded', () => {
   // Regression: Make sure #ifdef MACRO inside #else isn't expanded
   const program = `


### PR DESCRIPTION
Resolves https://github.com/ShaderFrog/glsl-parser/issues/24

I was looking into this a bit and I think the problem was that, when evaluating a conditional, although it would correctly call `.replace()` with the block that should run, the visitor would continue to visit all children, so the else blocks would step over any `#define`s in the if block.

I think what we want to have happen here is that if we replace the current node with something else, rather than continuing to visit the old node, the visitor should traverse the reversed node. This would definitely be a behaviour change, but I was thinking that if you wanted to replace but keep traversing the original tree, using `exit` instead of `enter` might be a better fit for that already. Let me know if I'm wrong in this assumption though, this changed behaviour could also easily just be an option in `visit()` instead!