### PR TITLE
Visit replaced nodes

### DIFF
--- a/src/ast/visit.ts
+++ b/src/ast/visit.ts
@@ -115,27 +115,28 @@ export const visit = (ast: Program | AstNode, visitors: NodeVisitors) => {
       }
     }
 
-    const toTraverse = (path.replaced as AstNode | undefined) ?? node;
-    const newPath = path.replaced
-      ? makePath(toTraverse, parent, parentPath, key, index)
-      : path;
-    Object.entries(toTraverse)
-      .filter(([_, nodeValue]) => isTraversable(nodeValue))
-      .forEach(([nodeKey, nodeValue]) => {
-        if (Array.isArray(nodeValue)) {
-          for (let i = 0, offset = 0; i - offset < nodeValue.length; i++) {
-            const child = nodeValue[i - offset];
-            const res = visitNode(child, toTraverse, newPath, nodeKey, i - offset);
-            if (res?.removed) {
-              offset += 1;
+    if (path.replaced) {
+      const replacedNode = path.replaced as AstNode;
+      visitNode(replacedNode, parent, parentPath, key, index);
+    } else {
+      Object.entries(node)
+        .filter(([_, nodeValue]) => isTraversable(nodeValue))
+        .forEach(([nodeKey, nodeValue]) => {
+          if (Array.isArray(nodeValue)) {
+            for (let i = 0, offset = 0; i - offset < nodeValue.length; i++) {
+              const child = nodeValue[i - offset];
+              const res = visitNode(child, node, path, nodeKey, i - offset);
+              if (res?.removed) {
+                offset += 1;
+              }
             }
+          } else {
+            visitNode(nodeValue, node, path, nodeKey);
           }
-        } else {
-          visitNode(nodeValue, toTraverse, newPath, nodeKey);
-        }
-      });
+        });
 
-    visitor?.exit?.(path as any);
+      visitor?.exit?.(path as any);
+    }
   };
 
   visitNode(ast);


### PR DESCRIPTION
I did [a little test of Babel](https://codesandbox.io/p/sandbox/ast-forked-ljkmf9?file=%2Fsrc%2Findex.js%3A42%2C1&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clwtmfrk200062e6amuw97wka%2522%252C%2522sizes%2522%253A%255B100%252C0%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clwtmfrk200022e6ayyuexovv%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clwtmfrk200032e6ale8kkx9a%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clwtmfrk200052e6amnkvdwbh%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B64.49275307474699%252C35.507246925253014%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clwtmfrk200022e6ayyuexovv%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clwtmfrk200012e6agir9n0u9%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Findex.js%2522%252C%2522state%2522%253A%2522IDLE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A42%252C%2522startColumn%2522%253A1%252C%2522endLineNumber%2522%253A42%252C%2522endColumn%2522%253A1%257D%255D%257D%255D%252C%2522id%2522%253A%2522clwtmfrk200022e6ayyuexovv%2522%252C%2522activeTabId%2522%253A%2522clwtmfrk200012e6agir9n0u9%2522%257D%252C%2522clwtmfrk200052e6amnkvdwbh%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clwtmfrk200042e6awm1p1crm%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clwtmfrk200052e6amnkvdwbh%2522%252C%2522activeTabId%2522%253A%2522clwtmfrk200042e6awm1p1crm%2522%257D%252C%2522clwtmfrk200032e6ale8kkx9a%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clwtmfrk200032e6ale8kkx9a%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Afalse%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D) and found that when you replace a node in `enter`, `exit` will not be called for that node. I've made the logic here mirror that: if a node gets replaced, it will just visit that node directly, which will then visit its children recursively. Otherwise, it will continue on to the children of the current node and then call `exit`.