### PR TITLE
5.0.0: Rename utility functions breaking API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ import { renameBindings, renameFunctions, renameTypes } from '@shaderfrog/glsl-p
 // ... parse an ast...
 
 // Suffix top level variables with _x
+// TODO UPDATE THIS
 renameBindings(ast.scopes[0], (name, node) => `${name}_x`);
 // Suffix function names with _x
 renameFunctions(ast.scopes[0], (name, node) => `${name}_x`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shaderfrog/glsl-parser",
-  "version": "3.0.0",
+  "version": "5.0.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shaderfrog/glsl-parser",
-      "version": "3.0.0",
+      "version": "5.0.0-beta.4",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.15.5",
@@ -21,7 +21,7 @@
         "prettier": "^2.1.2",
         "ts-jest": "^29.1.2",
         "ts-jest-resolver": "^2.0.1",
-        "typescript": "^5.3.3"
+        "typescript": "^5.5.3"
       },
       "engines": {
         "node": ">=16"
@@ -6308,9 +6308,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11132,9 +11132,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "type": "module",
   "description": "A GLSL ES 1.0 and 3.0 parser and preprocessor that can preserve whitespace and comments",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-beta.3",
   "type": "module",
   "description": "A GLSL ES 1.0 and 3.0 parser and preprocessor that can preserve whitespace and comments",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-beta.4",
   "type": "module",
   "description": "A GLSL ES 1.0 and 3.0 parser and preprocessor that can preserve whitespace and comments",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0",
   "type": "module",
   "description": "A GLSL ES 1.0 and 3.0 parser and preprocessor that can preserve whitespace and comments",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "4.1.1",
+  "version": "5.0.0-beta.1",
   "type": "module",
   "description": "A GLSL ES 1.0 and 3.0 parser and preprocessor that can preserve whitespace and comments",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "prettier": "^2.1.2",
     "ts-jest": "^29.1.2",
     "ts-jest-resolver": "^2.0.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.5.3"
   }
 }

--- a/src/parser/scope.test.ts
+++ b/src/parser/scope.test.ts
@@ -361,27 +361,6 @@ StructName_x main(in StructName_x x, StructName_x[3] y) {
   expect(Object.keys(ast.scopes[2].types)).toEqual(['StructName']);
 });
 
-test('shangus', () => {
-  const ast = c.parseSrc(`
-struct MyStruct { float y; };
-attribute vec3 position;
-vec3 func() {}`);
-
-  ast.scopes[0].bindings = renameBindings(
-    ast.scopes[0].bindings,
-    (name) => `${name}_x`
-  );
-  ast.scopes[0].functions = renameFunctions(
-    ast.scopes[0].functions,
-    (name) => `${name}_y`
-  );
-  ast.scopes[0].types = renameTypes(ast.scopes[0].types, (name) => `${name}_z`);
-
-  expect(Object.keys(ast.scopes[0].bindings)).toEqual(['position_x']);
-  expect(Object.keys(ast.scopes[0].functions)).toEqual(['func_y']);
-  expect(Object.keys(ast.scopes[0].types)).toEqual(['MyStruct_z']);
-});
-
 test('fn args shadowing global scope identified as separate bindings', () => {
   const ast = c.parseSrc(`
 attribute vec3 position;

--- a/src/parser/scope.ts
+++ b/src/parser/scope.ts
@@ -118,7 +118,6 @@ export const functionDeclarationSignature = (
   const quantifiers = specifier.quantifier || [];
 
   const parameterTypes = proto?.parameters?.map(({ specifier, quantifier }) => {
-    // todo: saving place on putting quantifiers here
     const quantifiers =
       // vec4[1][2] param
       specifier.quantifier ||

--- a/src/parser/test-helpers.ts
+++ b/src/parser/test-helpers.ts
@@ -67,37 +67,6 @@ export const buildParser = () => {
 //   }
 // };
 
-export const debugEntry = (bindings: ScopeIndex) => {
-  return Object.entries(bindings).map(
-    ([k, v]) =>
-      `${k}: (${v.references.length} references, ${
-        v.declaration ? '' : 'un'
-      }declared): ${v.references.map((r) => r.type).join(', ')}`
-  );
-};
-export const debugFunctionEntry = (bindings: FunctionScopeIndex) =>
-  Object.entries(bindings).flatMap(([name, overloads]) =>
-    Object.entries(overloads).map(
-      ([signature, overload]) =>
-        `${name} (${signature}): (${overload.references.length} references, ${
-          overload.declaration ? '' : 'un'
-        }declared): ${overload.references.map((r) => r.type).join(', ')}`
-    )
-  );
-
-export const debugScopes = (astOrScopes: Program | Scope[]) =>
-  console.log(
-    'Scopes:',
-    'scopes' in astOrScopes
-      ? astOrScopes.scopes
-      : astOrScopes.map((s) => ({
-          name: s.name,
-          types: debugEntry(s.types),
-          bindings: debugEntry(s.bindings),
-          functions: debugFunctionEntry(s.functions),
-        }))
-  );
-
 const middle = /\/\* start \*\/((.|[\r\n])+)(\/\* end \*\/)?/m;
 
 type ParseSrc = (src: string, options?: ParserOptions) => Program;

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -1,18 +1,24 @@
 import type { AstNode } from '../ast/index.js';
-import { Scope } from './scope.js';
+import {
+  FunctionScopeIndex,
+  Scope,
+  ScopeIndex,
+  TypeScopeIndex,
+} from './scope.js';
 
 export const renameBindings = (
-  scope: Scope,
-  mangle: (name: string, node: AstNode) => string
-) => {
-  Object.entries(scope.bindings).forEach(([name, binding]) => {
+  bindings: ScopeIndex,
+  mangle: (name: string) => string
+) =>
+  Object.entries(bindings).reduce<ScopeIndex>((acc, [name, binding]) => {
+    const mangled = mangle(name);
     binding.references.forEach((node) => {
       if (node.type === 'declaration') {
-        node.identifier.identifier = mangle(node.identifier.identifier, node);
+        node.identifier.identifier = mangled;
       } else if (node.type === 'identifier') {
-        node.identifier = mangle(node.identifier, node);
+        node.identifier = mangled;
       } else if (node.type === 'parameter_declaration' && node.identifier) {
-        node.identifier.identifier = mangle(node.identifier.identifier, node);
+        node.identifier.identifier = mangled;
         /* Ignore case of:
         layout(std140,column_major) uniform;
         uniform Material
@@ -25,72 +31,80 @@ export const renameBindings = (
         throw new Error(`Binding for type ${node.type} not recognized`);
       }
     });
-  });
-};
+    return {
+      ...acc,
+      [mangled]: binding,
+    };
+  }, {});
 
 export const renameTypes = (
-  scope: Scope,
-  mangle: (name: string, node: AstNode) => string
-) => {
-  Object.entries(scope.types).forEach(([name, type]) => {
+  types: TypeScopeIndex,
+  mangle: (name: string) => string
+) =>
+  Object.entries(types).reduce<TypeScopeIndex>((acc, [name, type]) => {
+    const mangled = mangle(name);
     type.references.forEach((node) => {
       if (node.type === 'type_name') {
-        node.identifier = mangle(node.identifier, node);
+        node.identifier = mangled;
       } else {
         console.warn('Unknown type node', node);
         throw new Error(`Type ${node.type} not recognized`);
       }
     });
-  });
-};
+    return {
+      ...acc,
+      [mangled]: type,
+    };
+  }, {});
 
 export const renameFunctions = (
-  scope: Scope,
-  mangle: (name: string, node: AstNode) => string
-) => {
-  Object.entries(scope.functions).forEach(([fnName, overloads]) => {
-    Object.entries(overloads).forEach(([signature, overload]) => {
-      overload.references.forEach((node) => {
-        if (node.type === 'function') {
-          node['prototype'].header.name.identifier = mangle(
-            node['prototype'].header.name.identifier,
-            node
-          );
-        } else if (
-          node.type === 'function_call' &&
-          node.identifier.type === 'postfix'
-        ) {
-          // @ts-ignore
-          const specifier = node.identifier.expression.identifier.specifier;
-          if (specifier) {
-            specifier.identifier = mangle(specifier.identifier, node);
+  functions: FunctionScopeIndex,
+  mangle: (name: string) => string
+) =>
+  Object.entries(functions).reduce<FunctionScopeIndex>(
+    (acc, [fnName, overloads]) => {
+      const mangled = mangle(fnName);
+      Object.entries(overloads).forEach(([signature, overload]) => {
+        overload.references.forEach((node) => {
+          if (node.type === 'function') {
+            node['prototype'].header.name.identifier = mangled;
+          } else if (
+            node.type === 'function_call' &&
+            node.identifier.type === 'postfix'
+          ) {
+            // @ts-ignore
+            const specifier = node.identifier.expression.identifier.specifier;
+            if (specifier) {
+              specifier.identifier = mangled;
+            } else {
+              console.warn('Unknown function node to rename', node);
+              throw new Error(
+                `Function specifier type ${node.type} not recognized`
+              );
+            }
+          } else if (
+            node.type === 'function_call' &&
+            'specifier' in node.identifier &&
+            'identifier' in node.identifier.specifier
+          ) {
+            node.identifier.specifier.identifier = mangled;
+          } else if (
+            node.type === 'function_call' &&
+            node.identifier.type === 'identifier'
+          ) {
+            node.identifier.identifier = mangled;
           } else {
             console.warn('Unknown function node to rename', node);
-            throw new Error(
-              `Function specifier type ${node.type} not recognized`
-            );
+            throw new Error(`Function for type ${node.type} not recognized`);
           }
-        } else if (
-          node.type === 'function_call' &&
-          'specifier' in node.identifier &&
-          'identifier' in node.identifier.specifier
-        ) {
-          node.identifier.specifier.identifier = mangle(
-            node.identifier.specifier.identifier,
-            node
-          );
-        } else if (
-          node.type === 'function_call' &&
-          node.identifier.type === 'identifier'
-        ) {
-          node.identifier.identifier = mangle(node.identifier.identifier, node);
-        } else {
-          console.warn('Unknown function node to rename', node);
-          throw new Error(`Function for type ${node.type} not recognized`);
-        }
+        });
       });
-    });
-  });
-};
+      return {
+        ...acc,
+        [mangled]: overloads,
+      };
+    },
+    {}
+  );
 
 export const xor = (a: any, b: any): boolean => (a || b) && !(a && b);

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -1,6 +1,8 @@
+import { Program } from '../ast/ast-types.js';
 import {
   FunctionOverloadIndex,
   FunctionScopeIndex,
+  Scope,
   ScopeEntry,
   ScopeIndex,
   TypeScopeEntry,
@@ -123,3 +125,34 @@ export const renameFunctions = (
   );
 
 export const xor = (a: any, b: any): boolean => (a || b) && !(a && b);
+
+export const debugEntry = (bindings: ScopeIndex) => {
+  return Object.entries(bindings).map(
+    ([k, v]) =>
+      `${k}: (${v.references.length} references, ${
+        v.declaration ? '' : 'un'
+      }declared): ${v.references.map((r) => r.type).join(', ')}`
+  );
+};
+export const debugFunctionEntry = (bindings: FunctionScopeIndex) =>
+  Object.entries(bindings).flatMap(([name, overloads]) =>
+    Object.entries(overloads).map(
+      ([signature, overload]) =>
+        `${name} (${signature}): (${overload.references.length} references, ${
+          overload.declaration ? '' : 'un'
+        }declared): ${overload.references.map((r) => r.type).join(', ')}`
+    )
+  );
+
+export const debugScopes = (astOrScopes: Program | Scope[]) =>
+  console.log(
+    'Scopes:',
+    'scopes' in astOrScopes
+      ? astOrScopes.scopes
+      : astOrScopes.map((s) => ({
+          name: s.name,
+          types: debugEntry(s.types),
+          bindings: debugEntry(s.bindings),
+          functions: debugFunctionEntry(s.functions),
+        }))
+  );

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -1,10 +1,33 @@
-import type { AstNode } from '../ast/index.js';
 import {
+  FunctionOverloadIndex,
   FunctionScopeIndex,
-  Scope,
+  ScopeEntry,
   ScopeIndex,
+  TypeScopeEntry,
   TypeScopeIndex,
 } from './scope.js';
+
+export const renameBinding = (binding: ScopeEntry, newName: string) => {
+  binding.references.forEach((node) => {
+    if (node.type === 'declaration') {
+      node.identifier.identifier = newName;
+    } else if (node.type === 'identifier') {
+      node.identifier = newName;
+    } else if (node.type === 'parameter_declaration' && node.identifier) {
+      node.identifier.identifier = newName;
+      /* Ignore case of:
+        layout(std140,column_major) uniform;
+        uniform Material {
+          uniform vec2 prop;
+        } 
+      */
+    } else if (node.type !== 'interface_declarator') {
+      console.warn('Unknown binding node', node);
+      throw new Error(`Binding for type ${node.type} not recognized`);
+    }
+  });
+  return binding;
+};
 
 export const renameBindings = (
   bindings: ScopeIndex,
@@ -12,30 +35,23 @@ export const renameBindings = (
 ) =>
   Object.entries(bindings).reduce<ScopeIndex>((acc, [name, binding]) => {
     const mangled = mangle(name);
-    binding.references.forEach((node) => {
-      if (node.type === 'declaration') {
-        node.identifier.identifier = mangled;
-      } else if (node.type === 'identifier') {
-        node.identifier = mangled;
-      } else if (node.type === 'parameter_declaration' && node.identifier) {
-        node.identifier.identifier = mangled;
-        /* Ignore case of:
-        layout(std140,column_major) uniform;
-        uniform Material
-        {
-        uniform vec2 prop;
-        }
-         */
-      } else if (node.type !== 'interface_declarator') {
-        console.warn('Unknown binding node', node);
-        throw new Error(`Binding for type ${node.type} not recognized`);
-      }
-    });
     return {
       ...acc,
-      [mangled]: binding,
+      [mangled]: renameBinding(binding, mangled),
     };
   }, {});
+
+export const renameType = (type: TypeScopeEntry, newName: string) => {
+  type.references.forEach((node) => {
+    if (node.type === 'type_name') {
+      node.identifier = newName;
+    } else {
+      console.warn('Unknown type node', node);
+      throw new Error(`Type ${node.type} not recognized`);
+    }
+  });
+  return type;
+};
 
 export const renameTypes = (
   types: TypeScopeIndex,
@@ -43,19 +59,53 @@ export const renameTypes = (
 ) =>
   Object.entries(types).reduce<TypeScopeIndex>((acc, [name, type]) => {
     const mangled = mangle(name);
-    type.references.forEach((node) => {
-      if (node.type === 'type_name') {
-        node.identifier = mangled;
-      } else {
-        console.warn('Unknown type node', node);
-        throw new Error(`Type ${node.type} not recognized`);
-      }
-    });
     return {
       ...acc,
-      [mangled]: type,
+      [mangled]: renameType(type, mangled),
     };
   }, {});
+
+export const renameFunction = (
+  overloadIndex: FunctionOverloadIndex,
+  newName: string
+) => {
+  Object.entries(overloadIndex).forEach(([signature, overload]) => {
+    overload.references.forEach((node) => {
+      if (node.type === 'function') {
+        node['prototype'].header.name.identifier = newName;
+      } else if (
+        node.type === 'function_call' &&
+        node.identifier.type === 'postfix'
+      ) {
+        // @ts-ignore
+        const specifier = node.identifier.expression.identifier.specifier;
+        if (specifier) {
+          specifier.identifier = newName;
+        } else {
+          console.warn('Unknown function node to rename', node);
+          throw new Error(
+            `Function specifier type ${node.type} not recognized`
+          );
+        }
+      } else if (
+        node.type === 'function_call' &&
+        'specifier' in node.identifier &&
+        'identifier' in node.identifier.specifier
+      ) {
+        node.identifier.specifier.identifier = newName;
+      } else if (
+        node.type === 'function_call' &&
+        node.identifier.type === 'identifier'
+      ) {
+        node.identifier.identifier = newName;
+      } else {
+        console.warn('Unknown function node to rename', node);
+        throw new Error(`Function for type ${node.type} not recognized`);
+      }
+    });
+  });
+  return overloadIndex;
+};
 
 export const renameFunctions = (
   functions: FunctionScopeIndex,
@@ -64,44 +114,9 @@ export const renameFunctions = (
   Object.entries(functions).reduce<FunctionScopeIndex>(
     (acc, [fnName, overloads]) => {
       const mangled = mangle(fnName);
-      Object.entries(overloads).forEach(([signature, overload]) => {
-        overload.references.forEach((node) => {
-          if (node.type === 'function') {
-            node['prototype'].header.name.identifier = mangled;
-          } else if (
-            node.type === 'function_call' &&
-            node.identifier.type === 'postfix'
-          ) {
-            // @ts-ignore
-            const specifier = node.identifier.expression.identifier.specifier;
-            if (specifier) {
-              specifier.identifier = mangled;
-            } else {
-              console.warn('Unknown function node to rename', node);
-              throw new Error(
-                `Function specifier type ${node.type} not recognized`
-              );
-            }
-          } else if (
-            node.type === 'function_call' &&
-            'specifier' in node.identifier &&
-            'identifier' in node.identifier.specifier
-          ) {
-            node.identifier.specifier.identifier = mangled;
-          } else if (
-            node.type === 'function_call' &&
-            node.identifier.type === 'identifier'
-          ) {
-            node.identifier.identifier = mangled;
-          } else {
-            console.warn('Unknown function node to rename', node);
-            throw new Error(`Function for type ${node.type} not recognized`);
-          }
-        });
-      });
       return {
         ...acc,
-        [mangled]: overloads,
+        [mangled]: renameFunction(overloads, mangled),
       };
     },
     {}


### PR DESCRIPTION
This introduces breaking changs to the utility API functions `renameBindings`, `renameFunctions`, and `renameTypes` and changes their signatures to take the specific scope index, rather than the full scope.

This also changes the signature of the `mangle()` function to no longer be passed the AST node in question to be mangled. `@shaderfrog/core` used this as a hack to set a property directly on AST nodes (`.doNotDescope`) to avoid other functions from touching it.

It also exports new individual utility functions `renameBinding` etc, and a helper debug function.

These changes are largely in service of `@shaderfrog/core` to support better AST manipulation by allowing for the renameFunctions to modify scope indices. This is to keep the scopes in sync with the manipulated AST, which allows for more utility functions to work on scope, and avoid re-visiting an AST to find variables after an AST manipulation.