### PR TITLE
Function macro expansion bug when multi argument macro arg has same name as user input

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "5.0.0",
+  "version": "5.1.0",
   "type": "module",
   "description": "A GLSL ES 1.0 and 3.0 parser and preprocessor that can preserve whitespace and comments",
   "scripts": {

--- a/src/preprocessor/preprocessor.test.ts
+++ b/src/preprocessor/preprocessor.test.ts
@@ -336,13 +336,21 @@ foo`);
 test(`function macro where source variable is same as macro argument`, () => {
   const program = `
 #define GE(x, y) x + y
-float z = GE(y, x);
+GE(y, x);
+GE(y.y, x.x);
+GE(yy, xx);
 `;
 
   const ast = parse(program);
   preprocessAst(ast);
+
+  // Ensure that if the argument passed to the fn GE(X) has the
+  // same name as the macro definition #define GE(X), it doesn't get expanded
+  // https://github.com/ShaderFrog/glsl-parser/issues/31
   expect(generate(ast)).toBe(`
-float z = y + x;
+y + x;
+y.y + x.x;
+yy + xx;
 `);
 });
 

--- a/src/preprocessor/preprocessor.test.ts
+++ b/src/preprocessor/preprocessor.test.ts
@@ -333,6 +333,19 @@ foo`;
 foo`);
 });
 
+test(`function macro where source variable is same as macro argument`, () => {
+  const program = `
+#define GE(x, y) x + y
+float z = GE(y, x);
+`;
+
+  const ast = parse(program);
+  preprocessAst(ast);
+  expect(generate(ast)).toBe(`
+float z = y + x;
+`);
+});
+
 test("macro that isn't macro function call call is expanded", () => {
   const program = `
 #define foo () yes expand

--- a/src/preprocessor/preprocessor.test.ts
+++ b/src/preprocessor/preprocessor.test.ts
@@ -335,17 +335,17 @@ foo`);
 
 test(`function macro where source variable is same as macro argument`, () => {
   const program = `
-#define GE(x, y) x + y
-GE(y, x);
-GE(y.y, x.x);
-GE(yy, xx);
+#define FN(x, y) x + y
+FN(y, x);
+FN(y.y, x.x);
+FN(yy, xx);
 `;
 
   const ast = parse(program);
   preprocessAst(ast);
 
-  // Ensure that if the argument passed to the fn GE(X) has the
-  // same name as the macro definition #define GE(X), it doesn't get expanded
+  // Ensure that if the argument passed to the fn FN(X) has the
+  // same name as the macro definition #define FN(X), it doesn't get expanded
   // https://github.com/ShaderFrog/glsl-parser/issues/31
   expect(generate(ast)).toBe(`
 y + x;


### PR DESCRIPTION
# Reproduce
```
#define F(x, y) x + y
F(y, x)
```
gets expanded to
```
x + x
```
because the replacement of each argument is a separate string replacement pass. So first it replaces the first argument, `x`, with what the user supplied, `y`, making the string `y + y`. Then it goes on to replace the second argument, `y`, with the user supplied `x`, making the string `x + x`.

This bug is triggered when a function macro has more than one argument, and the second argument (in this case `y` also matches what the user replace the first argument with.

# Fix
I switched the replacement to be a single pass replace, so there is no second pass to clobber the first replacement.

Addresses #31