### PR TITLE
Handling newline-escaped multiline lexemes in the preprocessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist
 .DS_Store
 tmp
 src/parser/parser.js
+src/preprocessor/preprocessor-parser.js
 tsconfig.tsbuildinfo

--- a/src/parser/test-helpers.ts
+++ b/src/parser/test-helpers.ts
@@ -45,6 +45,18 @@ export const buildParser = () => {
   };
 };
 
+export const buildPreprocessorParser = () => {
+  execSync(
+    'npx peggy --cache --format es -o src/preprocessor/preprocessor-parser.js src/preprocessor/preprocessor-grammar.pegjs'
+  );
+  const parser = require('../preprocessor/preprocessor-parser');
+  const parse = parser.parse as Parse;
+  return {
+    parse,
+    parser,
+  };
+};
+
 // Keeping this around in case I need to figure out how to do tracing again
 // Most of this ceremony around building a parser is dealing with Peggy's error
 // format() function, where the grammarSource has to line up in generate() and

--- a/src/preprocessor/index.ts
+++ b/src/preprocessor/index.ts
@@ -21,4 +21,11 @@ const preprocess = (src: string, options: PreprocessorOptions) =>
 
 export default preprocess;
 
-export { preprocessAst, preprocessComments, generate, preprocess, parser, visitPreprocessedAst };
+export {
+  preprocessAst,
+  preprocessComments,
+  generate,
+  preprocess,
+  parser,
+  visitPreprocessedAst,
+};

--- a/src/preprocessor/preprocessor-grammar.pegjs
+++ b/src/preprocessor/preprocessor-grammar.pegjs
@@ -7,7 +7,16 @@
  * https://docs.microsoft.com/en-us/cpp/preprocessor/grammar-summary-c-cpp?view=msvc-160
  */
 
+{{
+  import {
+    unescapeSrc
+  } from './preprocessor.js';
+}}
+
 {
+  // Remove escaped newlines before parsing
+  input = unescapeSrc(input);
+
   const node = (type, attrs) => ({
     type,
     ...attrs

--- a/src/preprocessor/preprocessor.ts
+++ b/src/preprocessor/preprocessor.ts
@@ -497,6 +497,10 @@ export type PreprocessorOptions = {
   stopOnError?: boolean;
 };
 
+// Remove escaped newlines, rather than try to handle them in the grammar
+const unescapeSrc = (src: string, options: PreprocessorOptions = {}) =>
+  src.replace(/\\[\n\r]/g, '');
+
 const preprocessAst = (
   program: PreprocessorProgram,
   options: PreprocessorOptions = {}
@@ -639,4 +643,4 @@ const preprocessAst = (
   return program;
 };
 
-export { preprocessAst, preprocessComments };
+export { preprocessAst, preprocessComments, unescapeSrc };


### PR DESCRIPTION
Rather than try to handle escaped newlines in the grammar, this change simply replaces escaped newlines into one line.

Addresses #43