### PR TITLE
Fixing bug where variable starting with true/false can't be rvalue

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "5.5.0",
+  "version": "5.5.1",
   "type": "module",
   "description": "A GLSL ES 1.0 and 3.0 parser and preprocessor that can preserve whitespace and comments",
   "scripts": {

--- a/src/parser/glsl-grammar.pegjs
+++ b/src/parser/glsl-grammar.pegjs
@@ -235,7 +235,7 @@ DOUBLECONSTANT = token:floating_constant _:_? { return node('double_constant', {
 INTCONSTANT = token:integer_constant _:_? { return node('int_constant', { token, whitespace: _ }); }
 UINTCONSTANT = token:integer_constant _:_? { return node('uint_constant', { token, whitespace: _ }); }
 BOOLCONSTANT
-  = token:("true" / "false") _:_ { return node('bool_constant', { token, whitespace:_ }); }
+  = token:("true" / "false") t:terminal { return node('bool_constant', { token, whitespace: t }); }
 FIELD_SELECTION = IDENTIFIER
 
 keyword "keyword" = ATTRIBUTE / VARYING / CONST / BOOL / FLOAT / DOUBLE / INT / UINT


### PR DESCRIPTION
Looks like this is from the true/false token copy-pasta from other number constants so it didn't check for a terminal at the end, so `true` consumed `trueothervarname` and then the parser barfs

Addresses #51